### PR TITLE
find_documentメソッドの編集

### DIFF
--- a/lib/litexbrl/edinet.rb
+++ b/lib/litexbrl/edinet.rb
@@ -23,13 +23,7 @@ module LiteXBRL
       private
 
       def read(doc)
-        document = find_document doc
-
-        document.read doc
-      end
-
-      def find_document(doc)
-        SecurityReport
+        SecurityReport.read doc
       end
     end
 

--- a/lib/litexbrl/edinet.rb
+++ b/lib/litexbrl/edinet.rb
@@ -29,18 +29,7 @@ module LiteXBRL
       end
 
       def find_document(doc)
-        namespaces = doc.namespaces
-
-        # TODO 委嬢する？
-        if security_report? namespaces
-          SecurityReport
-        else
-          raise StandardError.new "ドキュメントがありません"
-        end
-      end
-
-      def security_report?(namespaces)
-        namespaces.keys.any? {|ns| /jpcrp.+(asr|q1r|q2r|q3r|q4r)/ =~ ns }
+        SecurityReport
       end
     end
 


### PR DESCRIPTION
## Scope

有価証券報告書と四半期報告書をパースする際に不要になっている処理を削除した部分にかかる記述。
## 前提
- litexbrlは決算短信のパーサーのため、有価証券報告書と四半期報告書に適応していない
- 現状、有価証券報告書や四半期報告書はIFRS決算の決算方式で決算された報告書と通常通り日本基準で決算されている報告書が混在している
- IFRS決算の報告書だと、以下の記載で報告書と判定されずに処理が終了してパースされずに終わるというケースがあるため、削除する必要がある。

```
def security_report?(namespaces)
　namespaces.keys.any? {|ns| /jpcrp.+(asr|q1r|q2r|q3r|q4r)/ =~ ns }
　SecurityReport.read doc
end
```
## TODOリスト
- [x] 不要な処理の削除
