### PR TITLE
セグメント名が一部nilの問題の改修

### DIFF
--- a/lib/litexbrl/edinet/security_report.rb
+++ b/lib/litexbrl/edinet/security_report.rb
@@ -123,7 +123,7 @@ module LiteXBRL
           elm_array.each do |elm|
             segment = segment_hash
             segment[:segment_context_ref_name] = elm.content.delete(":")
-            segment[:segment_english_name] = to_segment_english_name(elm)
+            segment[:segment_english_name] = to_segment_english_name(elm.content)
             segment[:segment_sales] = find_value_jp_cor_segment(doc, NET_SALES, segment[:segment_context_ref_name], context[:context_duration], context[:context_consolidation])
             segment[:segment_operating_profit] = find_value_jp_cor_segment(doc, OPERATING_INCOME, segment[:segment_context_ref_name], context[:context_duration], context[:context_consolidation])
             xbrl.segments.push segment

--- a/lib/litexbrl/utils.rb
+++ b/lib/litexbrl/utils.rb
@@ -82,9 +82,7 @@ module LiteXBRL
       removed_str = [
         'ReportableSegmentsMember',
         'ReportableSegmentMember']
-
-      /:/ =~ elm
-      $'.gsub!(/#{removed_str.join('|')}/,'')
+      elm.content.match(%r{:(.+?)#{removed_str.join('|')}})[1]
     end
   end
 end

--- a/lib/litexbrl/utils.rb
+++ b/lib/litexbrl/utils.rb
@@ -79,10 +79,10 @@ module LiteXBRL
     end
 
     def to_segment_english_name(elm)
-      removed_str = [
+      removed_str_array = [
         'ReportableSegmentsMember',
         'ReportableSegmentMember']
-      elm.content.match(%r{:(.+?)#{removed_str.join('|')}})[1]
+      elm.match(%r{:(.*)})[1].gsub!(/#{removed_str_array.join('|')}/,'')
     end
   end
 end

--- a/lib/litexbrl/utils.rb
+++ b/lib/litexbrl/utils.rb
@@ -79,8 +79,12 @@ module LiteXBRL
     end
 
     def to_segment_english_name(elm)
+      removed_str = [
+        'ReportableSegmentsMember',
+        'ReportableSegmentMember']
+
       /:/ =~ elm
-      $'.gsub!(/ReportableSegmentsMember/,'')
+      $'.gsub!(/#{removed_str.join('|')}/,'')
     end
   end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -106,5 +106,19 @@ module LiteXBRL
       end
     end
 
+    describe '#to_segment_english_name' do
+      context 'セグメント名(英語)の取得' do
+        let(:elm_1) { "hoge:Result1_ReportableSegmentsMember" }
+        let(:elm_2) { "fuga:Result2_ReportableSegmentMember" }
+
+        it "末尾がReportableSegmentsMemberの場合" do
+          expect(to_segment_english_name elm_1).to eq "Result1_"
+        end
+        it "末尾がReportableSegmentMemberの場合" do
+          expect(to_segment_english_name elm_2).to eq "Result2_"
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
## Scope

セグメント名が一部nilになってしまう処理の改修にかかる処理の部分及び単体テスト
## 前提
- 現状、セグメント名が一部nilで取得してしまう箇所がある。
- 「〇〇Reportable **Segment** Member 」と 「〇〇Reportable **Segments** Member」 の2つがあり、「〇〇」の部分を取得する処理の以下のメソッドでは「〇〇Reportable **Segments** Member」の方しか対応しておらず、「〇〇Reportable **Segment** Member 」の方はnilになる。

```
    def to_segment_english_name(elm)
      /:/ =~ elm
      $'.gsub!(/ReportableSegmentsMember/,'')
    end
```
## TODOリスト
- [x] セグメント名が一部nilの問題の改修
- [x] 単体テストの確認 (未実装であった場合は実装)
