### PR TITLE
単一セグメントである旨の情報の取得

### DIFF
--- a/lib/litexbrl/edinet/account_item.rb
+++ b/lib/litexbrl/edinet/account_item.rb
@@ -60,6 +60,9 @@ module LiteXBRL
       # 従業員数
       NUMBER_OF_EMPLOYEES = ['NumberOfEmployees']
 
+      # 単一セグメント
+      SINGLE_SEGMENT = ['DescriptionOfFactThatCompanysBusinessComprisesSingleSegment']
+
       # セグメント毎のcontextRef
       SEGMENT_CONTEXT_REF_NAME = ['']
 

--- a/lib/litexbrl/edinet/financial_information.rb
+++ b/lib/litexbrl/edinet/financial_information.rb
@@ -19,11 +19,10 @@ module LiteXBRL
         def find_consolidation(doc)
           cons = doc.at_xpath("//xbrli:xbrl/xbrli:context[@id='CurrentYearDuration' or @id='CurrentYTDDuration']/xbrli:entity/xbrli:identifier")
           non_cons = doc.at_xpath("//xbrli:xbrl/xbrli:context[@id='CurrentYearDuration_NonConsolidatedMember' or @id='CurrentYTDDuration_NonConsolidatedMember']/xbrli:entity/xbrli:identifier")
-
-          if cons
-            "Consolidated"
-          elsif non_cons
+          if non_cons
             "NonConsolidatedMember"
+          elsif cons
+            "Consolidated"
           else
             raise StandardError.new("連結・非連結ともに該当しません。")
           end

--- a/lib/litexbrl/edinet/security_report.rb
+++ b/lib/litexbrl/edinet/security_report.rb
@@ -119,18 +119,16 @@ module LiteXBRL
         xbrl.single_segment = find_value_jp_cor(doc, SINGLE_SEGMENT, context[:context_duration], context[:context_consolidation])
 
         # セグメント情報
-        xbrl.segments = []
 
-        if xbrl.single_segment.nil?
-          elm_array = find_value_reportable_segments_member(doc, id[:reportable_segments_member])
-          elm_array.each do |elm|
-            segment = segment_hash
-            segment[:segment_context_ref_name] = elm.content.delete(":")
-            segment[:segment_english_name] = to_segment_english_name(elm)
-            segment[:segment_sales] = find_value_jp_cor_segment(doc, NET_SALES, segment[:segment_context_ref_name], context[:context_duration], context[:context_consolidation])
-            segment[:segment_operating_profit] = find_value_jp_cor_segment(doc, OPERATING_INCOME, segment[:segment_context_ref_name], context[:context_duration], context[:context_consolidation])
-            xbrl.segments.push segment
-          end
+        return xbrl unless xbrl.single_segment.nil?
+        elm_array = find_value_reportable_segments_member(doc, id[:reportable_segments_member])
+        xbrl.segments = elm_array.map do |elm|
+          segment = segment_hash
+          segment[:segment_context_ref_name] = elm.content.delete(":")
+          segment[:segment_english_name] = to_segment_english_name(elm)
+          segment[:segment_sales] = find_value_jp_cor_segment(doc, NET_SALES, segment[:segment_context_ref_name], context[:context_duration], context[:context_consolidation])
+          segment[:segment_operating_profit] = find_value_jp_cor_segment(doc, OPERATING_INCOME, segment[:segment_context_ref_name], context[:context_duration], context[:context_consolidation])
+          segment
         end
         xbrl
       end

--- a/lib/litexbrl/edinet/security_report.rb
+++ b/lib/litexbrl/edinet/security_report.rb
@@ -119,7 +119,7 @@ module LiteXBRL
         xbrl.single_segment = find_value_jp_cor(doc, SINGLE_SEGMENT, context[:context_duration], context[:context_consolidation])
 
         # セグメント情報
-        xbrl.segments = Array.new()
+        xbrl.segments = []
 
         if xbrl.single_segment.nil?
           elm_array = find_value_reportable_segments_member(doc, id[:reportable_segments_member])

--- a/lib/litexbrl/edinet/security_report.rb
+++ b/lib/litexbrl/edinet/security_report.rb
@@ -115,10 +115,13 @@ module LiteXBRL
         # 従業員数
         xbrl.number_of_employees = find_value_jp_cor(doc, NUMBER_OF_EMPLOYEES, context[:context_instant], context[:context_consolidation])
 
+        # 単一セグメント
+        xbrl.single_segment = find_value_jp_cor(doc, SINGLE_SEGMENT, context[:context_duration], context[:context_consolidation])
+
         # セグメント情報
         xbrl.segments = Array.new()
-        single_segment = doc.xpath "/xbrli:xbrl/jpcrp_cor:DescriptionOfFactThatCompanysBusinessComprisesSingleSegment"
-        if single_segment.empty?
+
+        if xbrl.single_segment.nil?
           elm_array = find_value_reportable_segments_member(doc, id[:reportable_segments_member])
           elm_array.each do |elm|
             segment = segment_hash

--- a/lib/litexbrl/edinet/security_report_attribute.rb
+++ b/lib/litexbrl/edinet/security_report_attribute.rb
@@ -9,7 +9,7 @@ module LiteXBRL
         :change_in_prior_net_sales, :change_in_prior_operating_income, :change_in_prior_ordinary_income, :change_in_prior_net_income,
         :forecast_net_sales, :forecast_operating_income, :forecast_ordinary_income, :forecast_net_income, :forecast_net_income_per_share,
         :change_in_forecast_net_sales, :change_in_forecast_operating_income, :change_in_forecast_ordinary_income, :change_in_forecast_net_income,
-        :owners_equity, :number_of_shares, :number_of_treasury_stock, :net_assets_per_share, :document_title_cover_page, :fiscal_year_cover_page, :company_name, :filing_date, :current_fiscal_year_start_date, :current_fiscal_year_end_date, :current_period_start_date, :current_period_end_date, :type_of_current_period, :number_of_employees, :segments, :segment_context_ref_name, :segment_english_name, :segment_sales, :egment_operating_profit
+        :owners_equity, :number_of_shares, :number_of_treasury_stock, :net_assets_per_share, :document_title_cover_page, :fiscal_year_cover_page, :company_name, :filing_date, :current_fiscal_year_start_date, :current_fiscal_year_end_date, :current_period_start_date, :current_period_end_date, :type_of_current_period, :number_of_employees, :single_segment, :segments, :segment_context_ref_name, :segment_english_name, :segment_sales, :egment_operating_profit
 
       def attributes
         {
@@ -50,6 +50,7 @@ module LiteXBRL
           current_period_end_date: current_period_end_date,
           type_of_current_period: type_of_current_period,
           number_of_employees: number_of_employees,
+          single_segment: single_segment,
           segments: segments
         }
       end


### PR DESCRIPTION
## Scope

単一セグメントである旨の情報の取得処理にかかる処理
## 前提
- 現状、セグメント情報が取得できない際に「単一セグメントであり、そもそも、セグメント情報の記載が省略されている」のか「セグメント情報は報告書内に記載されているが、包括タグなどにより取得しにくい状態」なのかが、判断できないため、「単一セグメントである旨の情報」をパースし、セグメント情報が取得できない際の状況の切り分けを行いたい。そのために「単一セグメントである旨の情報」をパースする処理を追記する。
- ココにかかる処理を追記した際にテストの変更はない。
## TODOリスト
- [x] 単一セグメントである旨の情報の取得処理にかかる処理
